### PR TITLE
changement sur 2 vues : pour déterminer qu'une commande est en retard…

### DIFF
--- a/models/KPIs/performance_entrepots.sql
+++ b/models/KPIs/performance_entrepots.sql
@@ -1,9 +1,10 @@
---- calculer le volume total traité par entrepôt et le nb de commandes expédiées
---- nb_retards : nombre de commandes livrées avec plus de 10 jours de délai entre comman de et livraison estimée.
---- COALESCE(..., 0) : remplace les valeurs NULL (absence de données) par 0.
----ROUND(...) : calcule le taux de retard en pourcentage, arrondi à 2 décimales.
+-- Calculer le volume total traité par entrepôt et le nombre de commandes expédiées
+-- nb_retards : nombre de commandes livrées avec un délai supérieur à la médiane globale
+-- COALESCE(..., 0) : remplace les valeurs NULL (absence de données) par 0
+-- ROUND(...) : calcule le taux de retard en pourcentage, arrondi à 2 décimales
 
 WITH volumes_par_entrepot AS (
+  -- Agrège le volume total traité par chaque entrepôt
   SELECT
     m.id_entrepot,
     SUM(m.volume_traite) AS total_volumes
@@ -11,18 +12,36 @@ WITH volumes_par_entrepot AS (
   GROUP BY m.id_entrepot
 ),
 
+delais AS (
+  -- Calcule le délai (en jours) entre commande et livraison estimée
+  SELECT
+    DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) AS delai
+  FROM {{ ref('mrt_fct_commandes') }} c
+),
+
+mediane_delai AS (
+  -- Calcule la médiane globale des délais
+  SELECT
+    PERCENTILE_CONT(delai, 0.5) OVER () AS mediane
+  FROM delais
+  LIMIT 1
+),
+
 commandes_par_entrepot AS (
+  -- Compte les commandes et les retards (délai > médiane globale) par entrepôt
   SELECT
     c.id_entrepot_depart,
     COUNT(*) AS nb_commandes,
     SUM(CASE 
-      WHEN DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) > 10
+      WHEN DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) > m.mediane
       THEN 1 ELSE 0 END
     ) AS nb_retards
   FROM {{ ref('mrt_fct_commandes') }} c
+  CROSS JOIN mediane_delai m
   GROUP BY c.id_entrepot_depart
 )
 
+-- Jointure finale avec la dimension entrepôts pour enrichir les données
 SELECT 
   e.id_entrepot, 
   e.localisation, 
@@ -37,6 +56,4 @@ SELECT
 FROM {{ ref('mrt_dim_entrepots') }} e
 LEFT JOIN volumes_par_entrepot v ON e.id_entrepot = v.id_entrepot
 LEFT JOIN commandes_par_entrepot c ON e.id_entrepot = c.id_entrepot_depart
-
 ORDER BY total_volumes DESC
-

--- a/models/KPIs/performance_retard_satisfaction.sql
+++ b/models/KPIs/performance_retard_satisfaction.sql
@@ -1,20 +1,42 @@
---- analyser la corrélation:  
--- Retard estimé : si la livraison est prévue >10 jours après la commande
---- annee_mois extraite de date de livraison estimee
---- selectionner uniquement les commandes qui ont été notées ( note_client)
-WITH commandes_avec_retard AS (
-    SELECT
-        c.id_commande,
-        c.date_commande,
-        c.date_livraison_estimee,
-        DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) > 10 AS retard_livraison,
-        FORMAT_DATE('%Y-%m', DATE(c.date_livraison_estimee)) AS annee_mois
-    FROM {{ ref('mrt_fct_commandes') }} c
+-- Analyser la corrélation :  
+-- Retard estimé : si la livraison est prévue avec un délai supérieur à la médiane globale
+-- annee_mois : extraite de la date de livraison estimée
+-- Sélectionner uniquement les commandes qui ont été notées (note_client)
+
+WITH delais AS (
+  -- Calcule le délai (en jours) entre commande et livraison estimée
+  SELECT
+    DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) AS delai
+  FROM {{ ref('mrt_fct_commandes') }} c
+),
+
+mediane_delai AS (
+  -- Calcule la médiane globale des délais
+  SELECT
+    PERCENTILE_CONT(delai, 0.5) OVER () AS mediane
+  FROM delais
+  LIMIT 1
+),
+
+commandes_avec_retard AS (
+  -- Marque les commandes comme en retard si leur délai dépasse la médiane globale,
+  -- et expose la valeur de la médiane dans chaque ligne
+  SELECT
+      c.id_commande,
+      c.date_commande,
+      c.date_livraison_estimee,
+      FORMAT_DATE('%Y-%m', DATE(c.date_livraison_estimee)) AS annee_mois,
+      DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) AS delai_commande,
+      m.mediane,
+      DATE_DIFF(DATE(c.date_livraison_estimee), DATE(c.date_commande), DAY) > m.mediane AS retard_livraison
+  FROM {{ ref('mrt_fct_commandes') }} c
+  CROSS JOIN mediane_delai m
 )
 
+-- Filtrage final : ne garder que les commandes notées
 SELECT
     cwr.*,
     s.note_client
 FROM commandes_avec_retard cwr
-JOIN {{ ref('mrt_fct_satisfaction') }} s   ---prendre les commandes qui ont été notées
+JOIN {{ ref('mrt_fct_satisfaction') }} s
   ON cwr.id_commande = s.id_commande


### PR DESCRIPTION
…, on regarde si son temps de livraison est > médiane globale toutes commandes et entrepots confondus.